### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
 language = "nodejs"
-run = ""
+run = "parcel -p 3000 src/views/index.html"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JavaScript Boilerplate
 
+[![Run on Repl.it](https://repl.it/badge/github/bspeidel/js-boilerplate)](https://repl.it/github/bspeidel/js-boilerplate)
+
 For lighting fast prototyping.
 
 ## Some features


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@netx/js-boilerplate).